### PR TITLE
Remove stripe.com from list

### DIFF
--- a/abpjf.txt
+++ b/abpjf.txt
@@ -10573,7 +10573,6 @@ _yahooads_
 ||striere.com^
 ||striete.com^
 ||stringenfolie.com^
-||stripe.com^$third-party
 ||sublimeskinz.com^$third-party
 ||sumapo.org^
 ||sumome.com^$third-party


### PR DESCRIPTION
Stripe's Checkout does not work with this line. Stripe does not deliver ads from its domain, so removing this will not have any negative impact.
